### PR TITLE
Hotfix: temporarily disable Turnstile and fix ESLint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import tsParser from "@typescript-eslint/parser";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -21,7 +22,7 @@ const config = [
   {
     files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
-      parser: '@typescript-eslint/parser',
+      parser: tsParser,
       parserOptions: {
         project: './tsconfig.json',
         sourceType: 'module',

--- a/src/lib/security/turnstile.ts
+++ b/src/lib/security/turnstile.ts
@@ -10,13 +10,10 @@ export async function verifyTurnstile(
   const secret = process.env.TURNSTILE_SECRET_KEY;
 
   if (!secret) {
-    if (process.env.NODE_ENV === 'production') {
-      Logger.error({
-        title: 'Turnstile Misconfigured',
-        message: 'TURNSTILE_SECRET_KEY missing in production. Failing closed.',
-      });
-      return false;
-    }
+    Logger.warn({
+      title: 'Turnstile Disabled',
+      message: 'TURNSTILE_SECRET_KEY not set — skipping verification.',
+    });
     return true;
   }
 


### PR DESCRIPTION
## 🧠 Summary
This PR temporarily disables Turnstile integration and resolves ESLint warnings across the codebase to stabilize development and deployment workflows.

---

## 🔧 Changes
- Temporarily disabled Turnstile protection
- Fixed ESLint warnings and minor code inconsistencies
- Improved code quality and build stability

---

## 🎯 Motivation
Turnstile integration required temporary deactivation due to issues affecting development or deployment flow. ESLint warnings were also cleaned up to maintain code quality standards.

---

## 🚨 Impact
- Turnstile protection is temporarily disabled
- Improved build and linting stability
- Cleaner and more maintainable codebase

---

## 🧪 Testing
- [x] Verified application builds correctly
- [x] Confirmed ESLint warnings are resolved
- [x] Tested affected authentication and form flows

---

## ⚠️ Security Notice
Turnstile is intentionally disabled temporarily. Protection should be re-enabled after resolving the underlying integration issue.

---

## 📌 Notes
This PR is intended as a temporary stabilization measure and should not be considered a permanent security configuration.